### PR TITLE
Login bugfix

### DIFF
--- a/backend/assaapp/tests.py
+++ b/backend/assaapp/tests.py
@@ -46,6 +46,18 @@ class AssaTestCase(TestCase):
             content_type='application/json')
         self.assertEqual(response.status_code, 204)
 
+    def test_put_signout(self):
+        response = self.put('/api/signout/', json.dumps({}), content_type='application/json')
+        self.assertEqual(response.status_code, 405)
+    
+    def test_get_signout(self):
+        response = self.get('/api/signout/')
+        self.assertEqual(response.status_code, 401)
+        response = self.post('/api/signin/', json.dumps({'email': 'cubec', 'password': 'cubec'}),
+            content_type='application/json')
+        response = self.get('/api/signout/')
+        self.assertEqual(response.status_code, 204)
+
     def test_get_signin(self):
         response = self.get('/api/signin/')
         self.assertEqual(response.status_code, 405)

--- a/backend/assaapp/tests.py
+++ b/backend/assaapp/tests.py
@@ -49,3 +49,17 @@ class AssaTestCase(TestCase):
     def test_get_signin(self):
         response = self.get('/api/signin/')
         self.assertEqual(response.status_code, 405)
+
+    def test_delete_user(self):
+        response = self.delete('/api/user/')
+        self.assertEqual(response.status_code, 405)
+
+    def test_get_user(self):
+        response = self.get('/api/user/')
+        self.assertEqual(response.status_code, 401)
+        response = self.post('/api/signin/', json.dumps({'email': 'cubec', 'password': 'cubec'}),
+            content_type='application/json')
+        response = self.get('/api/user/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('cubec', response.content.decode())
+        self.assertIn('grade', response.content.decode())

--- a/backend/assaapp/urls.py
+++ b/backend/assaapp/urls.py
@@ -3,5 +3,6 @@ from assaapp import views
 
 urlpatterns = [
     path('token/', views.token),
-    path('signin/', views.signin)
+    path('signin/', views.signin),
+    path('user/', views.user)
 ]

--- a/backend/assaapp/urls.py
+++ b/backend/assaapp/urls.py
@@ -4,5 +4,6 @@ from assaapp import views
 urlpatterns = [
     path('token/', views.token),
     path('signin/', views.signin),
+    path('signout/', views.signout),
     path('user/', views.user)
 ]

--- a/backend/assaapp/views.py
+++ b/backend/assaapp/views.py
@@ -22,6 +22,18 @@ def signin(request):
     else:
         return HttpResponseNotAllowed(['POST'])
 
+def user(request):
+    if request.method == 'GET':
+        if request.user.is_authenticated:
+            user = {'email': request.user.email, 'username': request.user.username, 
+                'grade': request.user.grade, 'department': request.user.department,
+                'is_authenticated': True}
+            return JsonResponse(user)
+        else:
+            return HttpResponse(status=401)
+    else:
+        return HttpResponseNotAllowed(['GET'])
+
 @ensure_csrf_cookie
 def token(request):
     if request.method == 'GET':

--- a/backend/assaapp/views.py
+++ b/backend/assaapp/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import render
-from django.contrib.auth import authenticate, login
+from django.contrib.auth import authenticate, login, logout
 from django.views.decorators.csrf import ensure_csrf_cookie
 from json import JSONDecodeError
 import json
@@ -21,6 +21,16 @@ def signin(request):
             return HttpResponse(status=401)
     else:
         return HttpResponseNotAllowed(['POST'])
+
+def signout(request):
+    if request.method == 'GET':
+        if request.user.is_authenticated:
+            logout(request)
+            return HttpResponse(status=204)
+        else:
+            return HttpResponse(status=401)
+    else:
+        return HttpResponseNotAllowed(['GET'])
 
 def user(request):
     if request.method == 'GET':

--- a/frontend/src/components/TimeTableView/TimeTableView.js
+++ b/frontend/src/components/TimeTableView/TimeTableView.js
@@ -33,7 +33,7 @@ const TimeTableView=(props)=>{//TODO: props.timetable
     ["20:00","","","","","",""],
     ["20:30","","","","","",""],];
     //TODO: fill tablestring
-    var tablehtml=tablestring.map(row=><tr><th width="100">{row[0]}</th><td width="100">{row[1]}</td><td width="100">{row[2]}</td><td width="100">{row[3]}</td><td width="100">{row[4]}</td><td width="100">{row[5]}</td><td width="100">{row[6]}</td></tr>)
+    var tablehtml=tablestring.map(row=><tr key={row[0]}><th width="100">{row[0]}</th><td width="100">{row[1]}</td><td width="100">{row[2]}</td><td width="100">{row[3]}</td><td width="100">{row[4]}</td><td width="100">{row[5]}</td><td width="100">{row[6]}</td></tr>)
     return (
         <div className='Timetableview'>
             <table id="timetable" border="1" bordercolor="red" width ="800" height="500">

--- a/frontend/src/containers/Login/Login.js
+++ b/frontend/src/containers/Login/Login.js
@@ -9,23 +9,28 @@ class Login extends Component {
         password: '',
     }
 
+    componentDidMount(){
+        this.props.onGetUser();
+    }
+
     handleLogin(){
         this.props.onLogin(this.state.email, this.state.password)
             .then(() => {
-                if(!this.props.storedLogin) {
+                if(!this.props.storedUser.is_authenticated) {
                     alert('이메일 또는 비밀번호가 잘못되었습니다.');
                 }
-            });
+            })
+            .catch(() => {});
     }
 
     render() {
-        let redirect = null;
-        if(this.props.storedLogin) {
-            redirect = <Redirect to='/main'/>
+        if(this.props.storedUser.is_authenticated) {
+            return (
+                <Redirect to='/main'/>
+            );
         }
         return (
             <div className='Login'>
-                {redirect}
                 <input type='text' id='email-input' value={this.state.email} placeholder='Email'
                     onChange={(event) => this.setState({email: event.target.value})}/>
                 <input type='password' id='pw-input' value={this.state.pasword} placeholder='Password'
@@ -38,7 +43,7 @@ class Login extends Component {
 
 const mapStateToProps = state => {
     return {
-        storedLogin: state.user.logged_in,
+        storedUser: state.user.user,
     }
 };
 
@@ -46,6 +51,8 @@ const mapDispatchToProps = dispatch => {
     return {
         onLogin: (email, password) =>
             dispatch(actionCreators.postSignin(email, password)),
+        onGetUser: () =>
+            dispatch(actionCreators.getUser()),
     }
 };
 

--- a/frontend/src/containers/Login/Login.test.js
+++ b/frontend/src/containers/Login/Login.test.js
@@ -11,13 +11,13 @@ import { history } from '../../store/store'
 import * as actionCreators from '../../store/actions/user';
 
 const stubState = {
-    logged_in: false
+    user: {is_authenticated: false}
 };
 
 const mockStore = getMockStore(stubState);
 
 describe('<Login />', () => {
-    let login, spyPostSignin;
+    let login, spyPostSignin, spyGetUser;
 
     beforeEach(() => {
         login = (
@@ -31,14 +31,15 @@ describe('<Login />', () => {
         );
         spyPostSignin = jest.spyOn(actionCreators, 'postSignin')
             .mockImplementation((email, password) => { return dispatch => {
-                    console.log(email + ' ' + password);
                     if(email === 'cubec@snu.ac.kr' && password === 'cubec') {
                         return Promise.resolve({status: 204});
                     } else {
                         return Promise.reject({status: 401});
                     }
-                } 
-            });
+            } 
+        });
+        spyGetUser = jest.spyOn(actionCreators, 'getUser')
+            .mockImplementation(() => { return dispatch => {}});
     });
 
     afterEach(() => { jest.clearAllMocks() });
@@ -56,9 +57,10 @@ describe('<Login />', () => {
         const spyAlert = jest.spyOn(window, 'alert')
             .mockImplementation(() => {});
         component.find('#email-input').simulate('change', {target: {value: email}});
-        component.find('#pw-input').simulate('change', {target: {value: password}});     
+        component.find('#pw-input').simulate('change', {target: {value: password}});
         component.find('#login-button').simulate('click');
-        const result = await spyPostSignin.mock.results[0].value().then(() => {return true}).catch(() => {return false});
+        const result = await spyPostSignin.mock.results[0].value()
+            .then(() => true).catch(() => false);
         expect(result).toBe(true);
     });
 
@@ -71,13 +73,14 @@ describe('<Login />', () => {
         component.find('#email-input').simulate('change', {target: {value: email}});
         component.find('#pw-input').simulate('change', {target: {value: password}});     
         component.find('#login-button').simulate('click');
-        const result = await spyPostSignin.mock.results[0].value().then(() => {return true}).catch(() => {return false});
+        const result = await spyPostSignin.mock.results[0].value()
+            .then(() => true).catch(() => false);
         expect(result).toBe(false);
     });
 
     it('should redirect to /main when logged_in is true', () => {
         const stubInitialState = {
-            logged_in: true
+            user: {is_authenticated: true}
         };
         const mockInitialStore = getMockStore(stubInitialState);
         const component = mount(

--- a/frontend/src/containers/Main/Main.js
+++ b/frontend/src/containers/Main/Main.js
@@ -9,7 +9,21 @@ class Main extends Component {
     state = {
         
     }
+
+    componentDidMount(){
+        this.props.onGetUser();
+    }
+
+    handleLogout() {
+        this.props.onLogout();
+    }
+
     render() {
+        if(!this.props.storedUser.is_authenticated) {
+            return (
+                <Redirect to='/login'/>
+            );
+        }
         var friend=[
             {id: 1, name: "정재윤", inclass: false, timeleft: "2147483647"},
             {id: 2, name: "구준서", inclass: false, timeleft: "2147483647"},
@@ -30,9 +44,7 @@ class Main extends Component {
                 <NavLink to=''>
                     <button id='personal-information-button'>INFORMATION</button>
                 </NavLink>
-                <NavLink to='/login'>
-                    <button id='logout-button'>LOGOUT</button>
-                </NavLink>
+                <button id='logout-button' onClick={() => this.handleLogout()}>LOGOUT</button>
                 <br/>
                 <TimeTableView id='timetable-table'/>
                 <MainPageFriendListView id='friend-list' friends={friend}/>
@@ -40,5 +52,20 @@ class Main extends Component {
         );
     }
 };
-export default Main;
-//export default connect(null, null)(Main);
+
+const mapStateToProps = state => {
+    return {
+        storedUser: state.user.user,
+    }
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        onGetUser: () =>
+            dispatch(actionCreators.getUser()),
+        onLogout: () =>
+            dispatch(actionCreators.getSignout()),
+    }
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/frontend/src/containers/Main/Main.test.js
+++ b/frontend/src/containers/Main/Main.test.js
@@ -1,23 +1,56 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import { Route, Redirect, Switch } from 'react-router-dom';
+import { shallow, mount} from 'enzyme';
+import { getMockStore } from '../../test-utils/mocks';
+import { ConnectedRouter } from 'connected-react-router';
+import { history } from '../../store/store'
 import Main from './Main';
-import {shallow,mount} from 'enzyme';
-import { Redirect, NavLink, BrowserRouter } from 'react-router-dom';
-//import { getMockStore } from '../mocks';
-//const store=getMockStore({});
-it('Main page render test', () => {
-    const component=mount(<BrowserRouter><Main/></BrowserRouter>);
-    const assabutton=component.find('#assa-logo-button');
-    const timetablebutton=component.find('#timetable-management-button');
-    const friendbutton = component.find('#friend-button');
-    const informationbutton = component.find('#personal-information-button');
-    const logoutbutton = component.find('#logout-button');
-    const timetable = component.find('#timetable-table');
-    const friendlist = component.find('#friend-list');
-    expect(assabutton.length).toBe(1);
-    expect(timetablebutton.length).toBe(1);
-    expect(friendbutton.length).toBe(1);
-    expect(informationbutton.length).toBe(1);
-    expect(logoutbutton.length).toBe(1);
-    expect(timetable.length).toBe(1);
-    expect(friendlist.length).toBe(1);
+
+import * as actionCreators from '../../store/actions/user';
+
+const stubState = {
+    user: {is_authenticated: true}
+};
+
+const mockStore = getMockStore(stubState);
+
+describe('<Main />', () => {
+    let main, spyGetUser, spyGetSignout;
+
+    beforeEach(() => {
+        main = (
+            <Provider store={mockStore}>
+                <ConnectedRouter history={history}>
+                    <Switch>
+                        <Route path='/' exact component={Main} />
+                    </Switch>
+                </ConnectedRouter>
+            </Provider>
+        );
+        spyGetUser = jest.spyOn(actionCreators, 'getUser')
+            .mockImplementation(() => { return dispatch => {}});
+        spyGetSignout = jest.spyOn(actionCreators, 'getSignout')
+            .mockImplementation(() => { return dispatch => {}});
+    });
+
+    afterEach(() => { jest.clearAllMocks() });
+
+    it('Main page render test', () => {
+        const component = mount(main);
+        const assabutton=component.find('#assa-logo-button');
+        const timetablebutton=component.find('#timetable-management-button');
+        const friendbutton = component.find('#friend-button');
+        const informationbutton = component.find('#personal-information-button');
+        const logoutbutton = component.find('#logout-button');
+        const timetable = component.find('#timetable-table');
+        const friendlist = component.find('#friend-list');
+        expect(assabutton.length).toBe(1);
+        expect(timetablebutton.length).toBe(1);
+        expect(friendbutton.length).toBe(1);
+        expect(informationbutton.length).toBe(1);
+        expect(logoutbutton.length).toBe(1);
+        expect(timetable.length).toBe(1);
+        expect(friendlist.length).toBe(1);
+    });
 });

--- a/frontend/src/store/actions/actionTypes.js
+++ b/frontend/src/store/actions/actionTypes.js
@@ -1,1 +1,2 @@
-export const POST_SIGNIN = "POST_SIGNIN";
+export const GET_AUTH = "GET_AUTH";
+export const GET_USER = "GET_USER";

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -4,5 +4,6 @@ axios.defaults.xsrfCookieName = 'csrftoken';
 axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN';
 
 export{
-    postSignin
+    postSignin,
+    getUser,
 } from './user';

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -6,4 +6,5 @@ axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN';
 export{
     postSignin,
     getUser,
+    getSignout,
 } from './user';

--- a/frontend/src/store/actions/user.js
+++ b/frontend/src/store/actions/user.js
@@ -16,3 +16,11 @@ export const getUser = () => {
             .catch(res => dispatch({type: actionTypes.GET_AUTH, is_authenticated: false}))
     }
 };
+
+export const getSignout = () => {
+    return dispatch => {
+        return axios.get('/api/signout/')
+            .then(res => dispatch({type: actionTypes.GET_AUTH, is_authenticated: false}))
+            .catch(() => {});
+    }
+};

--- a/frontend/src/store/actions/user.js
+++ b/frontend/src/store/actions/user.js
@@ -4,7 +4,15 @@ import axios from 'axios';
 export const postSignin = (email, password) => {
     return dispatch => {
         return axios.post('/api/signin/', {email: email, password: password})
-            .then(res => dispatch({type: actionTypes.POST_SIGNIN, logged_in: true}))
-            .catch(res => dispatch({type: actionTypes.POST_SIGNIN, logged_in: false}))
+            .then(res => dispatch({type: actionTypes.GET_AUTH, is_authenticated: true}))
+            .catch(res => dispatch({type: actionTypes.GET_AUTH, is_authenticated: false}))
+    }
+};
+
+export const getUser = () => {
+    return dispatch => {
+        return axios.get('/api/user/')
+            .then(res => dispatch({type: actionTypes.GET_USER, user: res.data}))
+            .catch(res => dispatch({type: actionTypes.GET_AUTH, is_authenticated: false}))
     }
 };

--- a/frontend/src/store/actions/user.test.js
+++ b/frontend/src/store/actions/user.test.js
@@ -12,12 +12,38 @@ describe('user action test', () => {
                 resolve(result);
             })
         })
+        axios.get = jest.fn(url => {
+            return new Promise((resolve, reject) => {
+                const result = {
+                    status: 200, data: null
+                };
+                resolve(result);
+            })
+        })
     })
 
-    it('should call postSignin', () => {
+    afterEach(() => { jest.clearAllMocks() });
+
+    it('should call postSignin', (done) => {
         store.dispatch(actionCreators.postSignin())
             .then(() => {
                 expect(axios.post).toHaveBeenCalledTimes(1);
+                done();
+            })
+    }) 
+
+    it('should call getSignout', (done) => {
+        store.dispatch(actionCreators.getSignout())
+            .then(() => {
+                expect(axios.get).toHaveBeenCalledTimes(1);
+                done();
+            })
+    }) 
+
+    it('should call getUser', (done) => {
+        store.dispatch(actionCreators.getUser())
+            .then(() => {
+                expect(axios.get).toHaveBeenCalledTimes(1);
                 done();
             })
     }) 

--- a/frontend/src/store/reducers/user.js
+++ b/frontend/src/store/reducers/user.js
@@ -1,13 +1,17 @@
 import * as actionTypes from '../actions/actionTypes';
 
 const initialState = {
-    logged_in: false,
+    user: {
+        is_authenticated: false,
+    },
 };
 
 const reducer = (state = initialState, action) => {
     switch(action.type){
-        case actionTypes.POST_SIGNIN:
-            return {...state, logged_in: action.logged_in};
+        case actionTypes.GET_AUTH:
+            return {...state, user: {is_authenticated: action.is_authenticated}};
+        case actionTypes.GET_USER:
+            return {...state, user: action.user}
         default:
             return {...state};
     }


### PR DESCRIPTION
Modification

* fixed login problem after refresh
* added logout functionality
* implemented more api(/user/, /signout/)
* fixed warning in timetable (by assigning key in every tr)
* more unittest

Expectation

* login status has to be remained after refreshing
* logout has to be done by pressing logout button in main page
* RED warnings(Errors?) must not be shown
* unittest > 80% for frontend and backend

Remaining Problem

* If a user refresh in a main page, it may instantly go to the login page and redirect after getting database from the server. This problem can be removed by reordering database fetching and rendering.