### PR TITLE
Add timetable_main and friend field in User model

### DIFF
--- a/backend/assaapp/models.py
+++ b/backend/assaapp/models.py
@@ -5,16 +5,20 @@ class UserManager(BaseUserManager):
     def create_user(self, email, username, password=None, grade=1, department=''):
         if not email:
             raise ValueError('User must have an email address')
-        
+
         user = self.model(
             email=self.normalize_email(email),
             username=username,
             grade=grade,
-            department=department,
+            department=department
         )
 
         user.set_password(password)
         user.save(using=self._db)
+
+        timetable_main = Timetable.objects.create(title='My timetable', user=user)
+        user.timetable_main = timetable_main
+        user.save()
         return user
     
     def create_superuser(self, email, username, password, grade=1, department=''):
@@ -37,6 +41,9 @@ class User(AbstractBaseUser):
     department = models.CharField(max_length=64)
     is_active = models.BooleanField(default=False)
     is_admin = models.BooleanField(default=False)
+    timetable_main = models.OneToOneField('Timetable', null=True, blank=True, related_name='user_main', on_delete=models.PROTECT)
+    friends = models.ManyToManyField('self', symmetrical=True)
+    friends_request = models.ManyToManyField('self', symmetrical=False)
 
     objects = UserManager()
     

--- a/backend/assaapp/tests.py
+++ b/backend/assaapp/tests.py
@@ -113,8 +113,8 @@ class AssaTestCase(TestCase):
         self.assertIn('grade', response.content.decode())
 
     def test_timetable(self):
-        timetable = Timetable.objects.get(id=1)
-        self.assertEqual(str(timetable), '21')
+        timetable = Timetable.objects.get(id=2)
+        self.assertEqual(str(timetable), 'My timetable')
 
     def test_get_timetable(self):
         response = self.get('/api/timetable/')
@@ -123,7 +123,7 @@ class AssaTestCase(TestCase):
             content_type='application/json')
         response = self.get('/api/timetable/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(2, len(json.loads(response.content.decode())))
+        self.assertEqual(3, len(json.loads(response.content.decode())))
 
     def test_delete_timetable(self):
         response = self.delete('/api/timetable/')


### PR DESCRIPTION
#27 

Detailed expectation : 

* When creating a user, one timetable named "My timetable" must be created and attach to the `user.timetable_main` without error. Also, `timetable.user` must be the user.
* When we try to delete main timetable, it has to raise error. 
* `friends` is symmetrical, so if we add user A add user B as a friend, then user A must be included in the User B's friend list.
* `friends_request` is asymmetrical, so even though we add user A add user B as a friend request, user A must NOT be included in the User B's friend request list.
* These properties have to be maintained on deletion, too.